### PR TITLE
Automatically create on first run without needing rebuild=true.

### DIFF
--- a/src/main/java/com/lennardf1989/bukkitex/MyDatabase.java
+++ b/src/main/java/com/lennardf1989/bukkitex/MyDatabase.java
@@ -178,16 +178,7 @@ public abstract class MyDatabase {
     }
 
     private void installDatabase(boolean rebuild) {
-        //Check if the database has to be rebuild
-        if(!rebuild) {
-            return;
-        }
-
-        //Create a DDL generator
-        SpiEbeanServer serv = (SpiEbeanServer) ebeanServer;
-        DdlGenerator gen = serv.getDdlGenerator();
-
-        //Check if the database already (partially) exists
+         //Check if the database already (partially) exists
         boolean databaseExists = false;
 
         List<Class<?>> classes = getDatabaseClasses();
@@ -205,7 +196,16 @@ public abstract class MyDatabase {
             }
         }
 
-        //Fire "before drop" event
+        //Check if the database has to be created or rebuilt
+        if(!rebuild && databaseExists) {
+            return;
+        }
+
+        //Create a DDL generator
+        SpiEbeanServer serv = (SpiEbeanServer) ebeanServer;
+        DdlGenerator gen = serv.getDdlGenerator();
+
+       //Fire "before drop" event
         try {
             beforeDropDatabase();
         }


### PR DESCRIPTION
Simple change to let the database get created the first time it's accessed if it doesn't already exist. This is as an alternative to passing rebuild=true in the config etc.
