### PR TITLE
Access to DataSourceConfig and ServerConfig during prepareDatabase

### DIFF
--- a/src/main/java/com/lennardf1989/bukkitex/MyDatabase.java
+++ b/src/main/java/com/lennardf1989/bukkitex/MyDatabase.java
@@ -125,6 +125,8 @@ public abstract class MyDatabase {
             sc.getDatabasePlatform().getDbDdlSyntax().setIdentity("");
         }
 
+        prepareDatabaseAdditionalConfig(ds, sc);
+
         //Finally the data source
         sc.setDataSourceConfig(ds);
 
@@ -384,6 +386,14 @@ public abstract class MyDatabase {
      * Method called after the loaded database has been created
      */
     protected void afterCreateDatabase() {}
+
+    /**
+     * Method called near the end of prepareDatabase, before the dataSourceConfig is attached to the serverConfig.
+     *
+     * @param dataSourceConfig
+     * @param serverConfig
+     */
+    protected void prepareDatabaseAdditionalConfig(DataSourceConfig dataSourceConfig, ServerConfig serverConfig) {}
 
     /**
      * Get the instance of the EbeanServer


### PR DESCRIPTION
Added overridable method to get access to DataSourceConfig and ServerConfig during prepareDatabase for additional configuration.

I find this useful because I sometimes want to set extra options (such as debugSql, and tweaking the logging).
